### PR TITLE
bump Go v1.22.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.18"
+          go-version-file: go.mod
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,23 +5,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Install Dependencies
-        run: go mod download
 
       - name: Test
         run: go test -race -v -coverprofile=profile.cov ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/mackerel-cloudwatch-forwarder
 
-go 1.17
+go 1.22.4
 
 require (
 	github.com/aws/aws-lambda-go v1.47.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Go version to 1.22.4.
  - Improved CI workflow by removing the caching of Go dependencies and setting up Go using the version specified in `go.mod`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->