### PR TITLE
runtimeをal2からal2023に更新

### DIFF
--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -6,4 +6,4 @@ docker run --rm -it \
     -e GO111MODULE=on \
     -v mackerel-cloudwatch-forwarder-cache:/go/pkg/mod \
     -v "$CURRENT":/go/src/github.com/shogo82148/mackerel-cloudwatch-forwarder \
-    -w /go/src/github.com/shogo82148/mackerel-cloudwatch-forwarder golang:1.18.2 "$@"
+    -w /go/src/github.com/shogo82148/mackerel-cloudwatch-forwarder golang:1.22.4 "$@"

--- a/template.yaml
+++ b/template.yaml
@@ -38,7 +38,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: mackerel-cloudwatch-forwarder
-      Runtime: provided.al2
+      Runtime: provided.al2023
       Timeout: 60
       CodeUri: dist.zip
       Policies:


### PR DESCRIPTION
## 内容
- al2のサポートが2023/06/30で切れるため、al2023に更新する
  - https://aws.amazon.com/jp/amazon-linux-2/faqs/#amazon-linux-2-lts-candidate-%E3%81%A8-amazon-linux-ami-%E3%81%AE%E3%82%B5%E3%83%9B%E3%83%BC%E3%83%88--o3nq58
- golangのバージョンが古いためbuildエラーとなっていたので更新する

## 動作確認
`buildエラー`
```
❯ make build          
mkdir -p dist
./run-in-docker.sh go build -tags lambda.norpc -o dist/bootstrap ./cmd/mackerel-cloudwatch-forwarder
Unable to find image 'golang:1.18.2' locally
1.18.2: Pulling from library/golang
d794814721d5: Pull complete 
bf62ee63325d: Pull complete 
29e37b4c58dd: Pull complete 
9cb366fec153: Pull complete 
a9d4d985d43a: Pull complete 
fd48963d4670: Pull complete 
a4113c97f5e3: Pull complete 
Digest: sha256:04fab5aaf4fc18c40379924674491d988af3d9e97487472e674d0b5fd837dfac
Status: Downloaded newer image for golang:1.18.2
go: errors parsing go.mod:
/go/src/github.com/shogo82148/mackerel-cloudwatch-forwarder/go.mod:3: invalid go version '1.22.4': must match format 1.23
make: *** [dist/bootstrap] Error 1
```

`修正後のtest結果`
```
❯ make test 
go test -v -race ./...
=== RUN   TestParseLabel
--- PASS: TestParseLabel (0.00s)
=== RUN   TestLabel_String
--- PASS: TestLabel_String (0.00s)
=== RUN   TestPostServiceMetricValues
--- PASS: TestPostServiceMetricValues (0.00s)
=== RUN   TestPostHostMetricValues
--- PASS: TestPostHostMetricValues (0.00s)
=== RUN   TestPostServiceMetricValues_TemporaryError
--- PASS: TestPostServiceMetricValues_TemporaryError (1.02s)
=== RUN   TestPostServiceMetricValues_ClientError
--- PASS: TestPostServiceMetricValues_ClientError (0.00s)
=== RUN   TestPostServiceMetricValues_Error
--- PASS: TestPostServiceMetricValues_Error (1.20s)
=== RUN   TestToMetricDataQuery
--- PASS: TestToMetricDataQuery (0.00s)
PASS
ok      github.com/shogo82148/mackerel-cloudwatch-forwarder     3.870s
?       github.com/shogo82148/mackerel-cloudwatch-forwarder/cmd/mackerel-cloudwatch-forwarder   [no test files]
go vet ./...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build image to Go 1.22.4
  * Updated Lambda function runtime to Amazon Linux 2023

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shogo82148/mackerel-cloudwatch-forwarder/pull/619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->