### PR TITLE
Bump Go 1.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go.mod
+          go-version: "1.26.3"
 
       - name: Test
         run: go test -race -v -coverprofile=profile.cov ./...

--- a/forwarder.go
+++ b/forwarder.go
@@ -408,10 +408,7 @@ func (fctx *forwardContext) publishMetric(ctx context.Context) {
 
 	// publush service metrics
 	for service, metrics := range fctx.serviceMetrics {
-		service, metrics := service, metrics
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			err := fctx.mackerel.PostServiceMetricValues(ctx, service, metrics)
 			if err != nil {
 				logrus.WithFields(logrus.Fields{
@@ -432,14 +429,12 @@ func (fctx *forwardContext) publishMetric(ctx context.Context) {
 					"count":   len(metrics),
 				}).Info("succeed to post service metrics")
 			}
-		}()
+		})
 	}
 
 	// publish host metrics
 	if len(fctx.hostMetrics) > 0 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			err := fctx.mackerel.PostHostMetricValues(ctx, []HostMetricValue(fctx.hostMetrics))
 			if err != nil {
 				logrus.WithFields(logrus.Fields{
@@ -455,7 +450,7 @@ func (fctx *forwardContext) publishMetric(ctx context.Context) {
 					"count": len(fctx.hostMetrics),
 				}).Info("succeed to post host metrics")
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/mackerel-cloudwatch-forwarder
 
-go 1.23
+go 1.25.0
 
 require (
 	github.com/aws/aws-lambda-go v1.54.0

--- a/mackerel.go
+++ b/mackerel.go
@@ -100,7 +100,7 @@ func (c *MackerelClient) newRequest(ctx context.Context, method, path string, bo
 	return req, nil
 }
 
-func (c *MackerelClient) postJSON(ctx context.Context, path string, payload interface{}) error {
+func (c *MackerelClient) postJSON(ctx context.Context, path string, payload any) error {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 

--- a/mackerel_test.go
+++ b/mackerel_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestPostServiceMetricValues(t *testing.T) {
-	ch := make(chan interface{}, 1)
+	ch := make(chan any, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("unexpected method: want %s, got %s", http.MethodPost, r.Method)
@@ -28,7 +28,7 @@ func TestPostServiceMetricValues(t *testing.T) {
 			t.Errorf("unexpected path: want %q, got %q", want, got)
 		}
 
-		var body interface{}
+		var body any
 		dec := json.NewDecoder(r.Body)
 		if err := dec.Decode(&body); err != nil {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -56,14 +56,14 @@ func TestPostServiceMetricValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var got interface{}
+	var got any
 	select {
 	case got = <-ch:
 	default:
 		t.Fatal("api is not called")
 	}
-	want := []interface{}{
-		map[string]interface{}{
+	want := []any{
+		map[string]any{
 			"name":  "metric.sum",
 			"time":  1234567890.0,
 			"value": 123.0,
@@ -75,7 +75,7 @@ func TestPostServiceMetricValues(t *testing.T) {
 }
 
 func TestPostHostMetricValues(t *testing.T) {
-	ch := make(chan interface{}, 1)
+	ch := make(chan any, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("unexpected method: want %s, got %s", http.MethodPost, r.Method)
@@ -87,7 +87,7 @@ func TestPostHostMetricValues(t *testing.T) {
 			t.Errorf("unexpected path: want %q, got %q", want, got)
 		}
 
-		var body interface{}
+		var body any
 		dec := json.NewDecoder(r.Body)
 		if err := dec.Decode(&body); err != nil {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -116,14 +116,14 @@ func TestPostHostMetricValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var got interface{}
+	var got any
 	select {
 	case got = <-ch:
 	default:
 		t.Fatal("api is not called")
 	}
-	want := []interface{}{
-		map[string]interface{}{
+	want := []any{
+		map[string]any{
 			"hostId": "host-abc",
 			"name":   "metric.sum",
 			"time":   1234567890.0,

--- a/query.go
+++ b/query.go
@@ -10,12 +10,12 @@ import (
 
 // Query is a query for AWS CloudWatch.
 type Query struct {
-	Service string        `json:"service,omitempty"`
-	Host    string        `json:"host,omitempty"`
-	Name    string        `json:"name,omitempty"`
-	Metric  []interface{} `json:"metric,omitempty"`
-	Stat    string        `json:"stat,omitempty"`
-	Default *float64      `json:"default,omitempty"`
+	Service string   `json:"service,omitempty"`
+	Host    string   `json:"host,omitempty"`
+	Name    string   `json:"name,omitempty"`
+	Metric  []any    `json:"metric,omitempty"`
+	Stat    string   `json:"stat,omitempty"`
+	Default *float64 `json:"default,omitempty"`
 }
 
 // ToMetricDataQuery converts the query to (cloudwatch/types).MetricDataQuery.
@@ -99,7 +99,7 @@ func ToMetricDataQuery(query []*Query) ([]types.MetricDataQuery, map[string]floa
 	return ret, defaults, nil
 }
 
-func interfaceToString(in interface{}) string {
+func interfaceToString(in any) string {
 	if s, ok := in.(string); ok {
 		return s
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -20,14 +20,14 @@ func TestToMetricDataQuery(t *testing.T) {
 				{
 					Service: "foo-bar",
 					Name:    "metric.sum",
-					Metric:  []interface{}{"Namespace", "MetricName"},
+					Metric:  []any{"Namespace", "MetricName"},
 					Stat:    "Sum",
 				},
 				// shorthand
 				{
 					Service: ".",
 					Name:    "metric.average",
-					Metric:  []interface{}{".", "."},
+					Metric:  []any{".", "."},
 					Stat:    "Average",
 				},
 			},
@@ -65,14 +65,14 @@ func TestToMetricDataQuery(t *testing.T) {
 				{
 					Host:   "host-foo-bar",
 					Name:   "metric.sum",
-					Metric: []interface{}{"Namespace", "MetricName", "Host-Dimension1", "foo", "Host-Dimension2", "bar"},
+					Metric: []any{"Namespace", "MetricName", "Host-Dimension1", "foo", "Host-Dimension2", "bar"},
 					Stat:   "Sum",
 				},
 				// shorthand
 				{
 					Host:   "host-hoge-fuga",
 					Name:   "metric.sum",
-					Metric: []interface{}{".", ".", ".", "hoge", ".", "fuga"},
+					Metric: []any{".", ".", ".", "hoge", ".", "fuga"},
 					Stat:   "Sum",
 				},
 			},

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -6,4 +6,4 @@ docker run --rm -it \
     -e GO111MODULE=on \
     -v mackerel-cloudwatch-forwarder-cache:/go/pkg/mod \
     -v "$CURRENT":/go/src/github.com/shogo82148/mackerel-cloudwatch-forwarder \
-    -w /go/src/github.com/shogo82148/mackerel-cloudwatch-forwarder golang:1.22.4 "$@"
+    -w /go/src/github.com/shogo82148/mackerel-cloudwatch-forwarder golang:1.26.3 "$@"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain version from 1.23 to 1.25.0
  * Pinned GitHub Actions CI workflow to Go version 1.26.3
  * Updated Docker build container to golang:1.26.3 for consistent build environments

* **Refactor**
  * Streamlined metric publishing goroutine management patterns
  * Modernized type declarations to use latest Go language features

* **Tests**
  * Aligned test cases with updated type system usage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shogo82148/mackerel-cloudwatch-forwarder/pull/623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->